### PR TITLE
docs: sweep CLAUDE.md + README for post-modernization state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,30 +10,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Android app — Udacity Android Developer Nanodegree "Popular Movies" Stage 2 submission. Browses popular/top-rated movies from TMDb, plus a local "favorites" collection with trailers and reviews on the detail screen. Every legacy source file carries an Udacity-honor-code header stating the code is reference-only; preserve that header on edits to existing files. New files may use a simpler license header or none.
 
-**The repository is mid-modernization.** Legacy code is Java + Dagger 2 + RxJava 3 + LiveData + DataBinding + ViewBinding on AGP 4.1. The agreed target stack is below — write new code against the target, migrate legacy code task-by-task with a tracking issue per migration.
+**Stack state.** The data, DI, imaging, and JSON layers have all been migrated to the §2 target stack (Kotlin + Coroutines/Flow + Hilt + Coil + kotlinx.serialization on AGP 9 / Gradle Kotlin DSL with a version catalog). What's still legacy is **the UI layer**: XML layouts, DataBinding/ViewBinding, two Activities. The Compose + Navigation-Compose migration is the last big lane. Until that lands, keep writing new UI in a Compose-friendly shape (`StateFlow<UiState>`, hoisted state) so the eventual swap is mechanical.
 
 ---
 
 ## 2. Target stack (Google-recommended, agreed conventions)
 
-| Concern | Target | Replaces (legacy) |
+| Concern | Target | Status |
 |---|---|---|
-| Language | **Kotlin (idiomatic)** | Java |
-| UI | **Jetpack Compose** | XML layouts + DataBinding/ViewBinding |
-| Architecture | **MVVM + UDF** (immutable `UiState` data class, `StateFlow` from `ViewModel`, state hoisted into Composables) | LiveData-driven Activities |
-| Async | **Coroutines + Flow / StateFlow** — no `Single`/`Observable`, no `LiveData` | RxJava 3, LiveData |
-| DI | **Hilt** | Dagger 2 (manual `@Component`) |
-| Annotation processing | **KSP** | kapt / `annotationProcessor` |
-| Build | **Gradle Kotlin DSL** + **`gradle/libs.versions.toml`** version catalog + convention plugins in `build-logic/` | Groovy `build.gradle` with hardcoded versions |
-| Coverage | **Kover** | — |
-| Format | **Spotless** (with ktlint) | — |
-| Static analysis | **Detekt** | Android Lint only |
-| Image loading | **Coil** (Compose-native) | Glide |
-| Navigation | **Navigation-Compose** (or Navigation 3 when stable — see android/skills `navigation-3`) | Activity-to-Activity Intents |
-| Local persistence (structured) | Room (keep) — but expose Flows, not LiveData | Room with LiveData DAO methods |
-| Local persistence (key/value) | **DataStore** (Preferences DataStore for simple key/value, Proto DataStore for typed). **Forbidden: `SharedPreferences`, `PreferenceManager`, `getDefaultSharedPreferences`, anything in `androidx.preference:*`.** | SharedPreferences |
-| Networking | Retrofit + OkHttp + **kotlinx.serialization** + coroutine `suspend` functions | Retrofit + Gson + RxJava `Single` |
-| JSON | **kotlinx.serialization** (compile-time, no reflection). If Moshi is unavoidable in some module, use **Moshi codegen** (`com.squareup.moshi:moshi-kotlin-codegen` via KSP) — never the reflective `KotlinJsonAdapterFactory`. | Gson |
+| Language | **Kotlin (idiomatic)** | Done — pre-modernization (Java already converted). |
+| UI | **Jetpack Compose** | **Pending** — still XML + DataBinding/ViewBinding. |
+| Architecture | **MVVM + UDF** (immutable `UiState` data class, `StateFlow` from `ViewModel`, state hoisted into Composables) | Partial — VMs expose `StateFlow<T>`; the single immutable-`UiState` consolidation per screen is still pending. |
+| Async | **Coroutines + Flow / StateFlow** — no `Single`/`Observable`, no `LiveData` | Done — #20. |
+| DI | **Hilt** | Done — #21. |
+| Annotation processing | **KSP** | Pending — currently kapt for both Hilt and Room. |
+| Build | **Gradle Kotlin DSL** + **`gradle/libs.versions.toml`** version catalog + convention plugins in `build-logic/` | Partial — Gradle Kotlin DSL ✓, version catalog ✓; convention plugins / `build-logic/` still pending. |
+| Coverage | **Kover** | Done (≥60% line gate). |
+| Format | **Spotless** (with ktlint) | Pending. |
+| Static analysis | **Detekt** | Pending. |
+| Image loading | **Coil** (Compose-native, behind `ImageLoader` interface) | Done — #23. |
+| Navigation | **Navigation-Compose** (or Navigation 3 when stable — see android/skills `navigation-3`) | Pending — comes with the Compose migration. |
+| Local persistence (structured) | Room — exposes Flows, not LiveData | Done — #20. |
+| Local persistence (key/value) | **DataStore** (Preferences DataStore for simple key/value, Proto DataStore for typed). **Forbidden: `SharedPreferences`, `PreferenceManager`, `getDefaultSharedPreferences`, anything in `androidx.preference:*`.** | N/A — no key/value usage in the app yet. Rule stays in force for any future settings screen. |
+| Networking | Retrofit + OkHttp + **kotlinx.serialization** + coroutine `suspend` functions | Done — #20 (`suspend`) + #24 (kotlinx). |
+| JSON | **kotlinx.serialization** (compile-time, no reflection). If Moshi is unavoidable in some module, use **Moshi codegen** (`com.squareup.moshi:moshi-kotlin-codegen` via KSP) — never the reflective `KotlinJsonAdapterFactory`. | Done — #24. |
+| Connectivity | `NetworkMonitor` interface backed by `ConnectivityManager.NetworkCallback` (`Flow<Boolean>`); collected in VMs via `stateIn`; no synchronous `isNetworkConnected(context)` polling. | Done — #18. |
+| Launcher SDK floor | `minSdk = 26` (adaptive-icon-only delivery; no `mipmap-*dpi/` PNGs). | Done — #17. |
 
 **Why MVVM+UDF over full MVI:** Compose's recomposition model already enforces unidirectional flow when state is a single immutable `UiState` exposed via `StateFlow`. This is the *Now in Android* official sample pattern. Full reducer/intent-class MVI is heavier and unnecessary at this app's scale; we can evolve to it if state grows complex enough to warrant it.
 
@@ -108,9 +110,9 @@ Once Detekt/Spotless are wired:
 ### Coverage rules
 
 - Kover plugin is applied in `app/build.gradle.kts` with a `koverVerify` rule pinning min line coverage to **60%**.
-- Excluded from coverage: generated code (Dagger/Room/DataBinding/Glide/R/BuildConfig), Activities, adapters, BindingAdapters, Dagger DI graph, factory glue that touches `MoviesApp`, DTOs/entities in `data.model.*`, and `AppExecutors` (Android-framework-tied; slated for removal with the Coroutines migration).
-- Production code that legitimately needs the `Build.VERSION.SDK_INT` check should expose an `@VisibleForTesting internal` overload that takes an `sdkInt: Int` parameter (see `ConnectionUtils.isNetworkConnected`) so both branches can be covered without Robolectric.
-- ViewModels take their dependencies via constructor (`AppRepository`, etc.) so they're JVM-unit-testable without Robolectric. The `*ViewModelFactory` companions own the `(application as MoviesApp).movieComponent.getAppRepository()` lookup and are excluded from coverage; they go away with Hilt.
+- Excluded from coverage: Hilt code-gen (`Hilt_*`, `*HiltModules*`, `*HiltComponents*`, `*_GeneratedInjector`, `dagger.hilt.internal.*`, `hilt_aggregated_deps`), Room/DataBinding/R/BuildConfig generated code, Activities, RecyclerView adapters, BindingAdapters, the `di.module` package, DTOs/entities in `data.model.*`, and the `ui.image` package (Coil delegate + interface).
+- ViewModels take their dependencies via constructor injection (`MovieRepository`, `NetworkMonitor` — both interfaces) so they're JVM-unit-testable with simple mockito-kotlin `mock<MovieRepository>()` — no Robolectric, no Hilt test components.
+- `DetailViewModel` uses `SavedStateHandle` for its `movieId` argument; tests construct `SavedStateHandle(mapOf(MainActivity.MOVIE_OBJECT to sampleMovie()))` directly.
 
 ---
 
@@ -118,7 +120,7 @@ Once Detekt/Spotless are wired:
 
 - `compileSdk` 34, `targetSdk` 33, `minSdk` 26
 - Java 8 source/target (Kotlin `jvmTarget = "1.8"`)
-- AGP 9.2.1, Gradle 9.4.1, Kotlin 2.2.10 (kapt still in use; KSP migration is a follow-up)
+- AGP 9.2.1, Gradle 9.4.1, Kotlin 2.2.10 (kapt for Hilt + Room — KSP migration is a follow-up)
 - Repos: `google()` + `mavenCentral()` (jcenter removed)
 - Daemon JVM pinned to JDK 17 via `gradle/gradle-daemon-jvm.properties`; `org.gradle.toolchains.foojay-resolver-convention` 0.10.0 enabled in `settings.gradle.kts`
 - DataBinding *and* ViewBinding both enabled (`app/build.gradle.kts:56-60`) — both slated for removal in the Compose migration
@@ -126,19 +128,23 @@ Once Detekt/Spotless are wired:
 - ProGuard/R8 disabled in release (`isMinifyEnabled = false`)
 - `gradle.properties` carries AGP-9-upgrade-utility stability flags pinning AGP-7-era behavior (`android.nonTransitiveRClass=false`, `android.newDsl=false`, etc.). These are deprecated and emit warnings; they should be flipped one at a time in follow-up issues.
 
-Bumped together with AGP 9 to avoid Kotlin-2.2-metadata kapt failures: Dagger 2.50 → 2.56.2 (now Hilt 2.56.2 — see §7), Room 2.2.5 → 2.7.2, Glide 4.11.0 → 4.16.0 (retired in #23). Per §2.
+Current direct deps (canonical versions live in `gradle/libs.versions.toml`):
 
-Active in #18: **Coroutines** (`kotlinx-coroutines-android` 1.8.1) explicit, **Lifecycle 2.2.0 → 2.8.7** (`runtime-ktx` + `viewmodel-ktx`) so `viewModelScope`, `repeatOnLifecycle`, and `stateIn` are available. The `lifecycle-legacy` bundle was renamed to `lifecycle`.
-
-After #20: **RxJava and LiveData are gone.** Retrofit calls are `suspend fun`, Room reads return `Flow`, Room writes are `suspend fun`, ViewModels expose `StateFlow<T>` exclusively. `AppExecutors`, `CompositeDisposable`, `lifecycle-livedata-ktx`, and the `rxjava-legacy` bundle are removed.
-
-After #24: **Gson is gone.** JSON is **kotlinx.serialization** (compile-time, no reflection). Retrofit uses `converter-kotlinx-serialization` (Retrofit 2.11.0). The `Movie` dual-purpose class is split into `MovieEntity` (Room), `MovieDto` (wire), and a Parcelable domain `Movie` — see §7. Mappers in `data/Mappers.kt`.
+- **Hilt** 2.56.2 (DI; `@HiltAndroidApp`, `@HiltViewModel`, `@AndroidEntryPoint`, `@Binds`/`@Provides`/`@InstallIn(SingletonComponent::class)`)
+- **Coroutines** `kotlinx-coroutines-android` 1.8.1 + `-test`
+- **Lifecycle** 2.8.7 (`runtime-ktx` + `viewmodel-ktx`; LiveData artifact intentionally absent)
+- **Retrofit** 2.11.0 + `converter-kotlinx-serialization` + `okhttp-logging-interceptor`
+- **kotlinx.serialization** 1.7.3 (`Json { ignoreUnknownKeys = true; explicitNulls = false }`)
+- **Room** 2.7.2 (DAO returns `Flow<…>`; writes are `suspend`)
+- **Coil** 2.7.0 (hidden behind `ui.image.ImageLoader` interface)
+- **Activity** 1.9.3 (for `by viewModels()` reaching Hilt's factory)
+- **Timber** 4.7.1 (still on the legacy version because `WrongTimberUsageDetector` is `LintError`-disabled — bump deferred until a structured-logging migration)
 
 ---
 
-## 7. Legacy architecture (what's there now)
+## 7. Current architecture
 
-MVVM + single-Repository, DI via **Hilt** (Dagger 2.x compiler under the hood). Replace remaining legacy lanes one by one.
+MVVM + single-Repository, DI via **Hilt**. The data, DI, imaging, and JSON layers all sit on the target stack; only the UI layer (XML + Activities) is still legacy — see "Still to migrate" at the end of this section.
 
 ```
 @AndroidEntryPoint Activity → @HiltViewModel ViewModel → MovieRepository (interface)
@@ -159,11 +165,20 @@ MVVM + single-Repository, DI via **Hilt** (Dagger 2.x compiler under the hood). 
 - `MovieRepositoryImpl`: network reads are `suspend fun` returning `List<T>` (the unwrap-then-map from `MoviesList`/`ReviewsList`/`TrailerList` happens inside `NetworkDataSource`, which then maps `MovieDto → Movie` via `data/Mappers.kt`). Room reads are `Flow<List<Movie>>` / `Flow<Movie?>` (`LocalDataSource` maps `MovieEntity → Movie`). Writes are `suspend fun`. **No `LiveData`, no `CompositeDisposable`, no `clearDisposables`** — cancellation rides `viewModelScope`.
 - ViewModels expose **`StateFlow<T>` only**. One-shot network results use `MutableStateFlow<T>` updated from `viewModelScope.launch { runCatching { … }.onSuccess { _state.value = it }.onFailure { Timber.w(…) } }`; reactive Room reads use `repository.flow.stateIn(viewModelScope, WhileSubscribed(5_000), initialValue)`. **Never re-introduce `LiveData` exposure.**
 - Activities collect VM `StateFlow`s with `lifecycleScope.launch { repeatOnLifecycle(STARTED) { vm.flow.collect { … } } }`. **No `.observe(this)` callsites.** When a single drawer-style screen flips between multiple flow sources (see `MainActivity.bindMovies`), keep a `currentJob: Job?` field and cancel/replace it on path change.
-- `Movie` is the **domain type** only — a `@Parcelize data class` in `data.model`. Room uses `MovieEntity` (`data.local`, `@Entity(tableName = "favorite_movies")` with an auto-generated PK + unique `tmdb_id` column). Network uses `MovieDto` (`data.model`, `@Serializable`). Mappers (`data/Mappers.kt`) translate at the data-source edge; **domain code never sees `MovieDto` or `MovieEntity`**. The favorite-by-id lookup queries `WHERE tmdb_id = :tmdbId` (no longer relies on the PK happening to equal the TMDb id).
-- Two activities: `MainActivity` (RecyclerView grid, span 2 portrait / 4 landscape) and `DetailActivity`. Sort mode (`"Popular"`/`"Top Rated"`/`"Favorites"`) is a `String` saved via `onSaveInstanceState`. Both activities will be replaced by Compose screens hosted in a single `ComponentActivity` with `NavHost`.
+- `Movie` is the **domain type** only — a `@Parcelize data class` in `data.model`. Room uses `MovieEntity` (`data.local`, `@Entity(tableName = "favorite_movies")` with an auto-generated PK + unique `tmdb_id` column). Network uses `MovieDto` (`data.model`, `@Serializable`). Mappers (`data/Mappers.kt`) translate at the data-source edge; **domain code never sees `MovieDto` or `MovieEntity`**. The favorite-by-id lookup queries `WHERE tmdb_id = :tmdbId`.
+- **Comparing `Movie` instances: use `movieId` only, not `==`.** The same logical TMDb movie has `isFavorite = false` when it came from the network DTO mapper and `isFavorite = true` when it came from the Room entity mapper, so full data-class equality returns false for genuinely-equal entities. The fix in `DetailActivity` (post-#27) is the canonical example.
 - Image loading: `ui.image.ImageLoader` interface + `CoilImageLoader` impl; `MoviesApp` implements `ImageLoaderHost` so the two `@BindingAdapter`s (`posterUrl`, `backDropUrl`) reach the loader via `(context.applicationContext as ImageLoaderHost).imageLoader.load(...)`. **Only `CoilImageLoader.kt` imports `coil.*`** — never reference Coil directly from UI / VM / adapter callsites. Compose migration swaps the impl for a Composable wrapper around `coil.compose.AsyncImage`.
 - Logging: Timber, planted only in debug, with tag `Constants.TAG = "MyApp"`.
 - Connectivity: `NetworkMonitor` (`data/network/NetworkMonitor.kt`) exposes `Flow<Boolean>` via `callbackFlow` + `ConnectivityManager.NetworkCallback`. Used by `MainViewModel.isOnline: StateFlow<Boolean>` (collected by `MainActivity` with `repeatOnLifecycle(STARTED)`). Primary constructor takes injected `ConnectivityManager?` + `NetworkRequest` (Hilt-provided in production via `NetworkMonitorModule`; tests pass mocks directly). **Never re-introduce synchronous `isNetworkConnected(context)` polling** — observe the flow.
+
+### Still to migrate
+
+- **UI → Compose + Navigation-Compose.** Two Activities (`MainActivity` RecyclerView grid + `DetailActivity`), `R.layout.*` XML, DataBinding `@BindingAdapter`s, ViewBinding flag. Sort mode (`"Popular"`/`"Top Rated"`/`"Favorites"`) is a `String` saved via `onSaveInstanceState` — that becomes `SavedStateHandle` / nav arg in the Compose VM. Both activities collapse into one `ComponentActivity` hosting a `NavHost`. Drop DataBinding + ViewBinding from `buildFeatures`. Use `coil.compose.AsyncImage` to retire the `@BindingAdapter` indirection.
+- **UiState consolidation** per screen — fold the per-collection `StateFlow<List<Movie>>`s in `MainViewModel` and the `reviews` / `trailers` / `favoriteMovie` triple in `DetailViewModel` into a single immutable `UiState` data class per screen.
+- **KSP** for both Hilt and Room compilers (currently kapt).
+- **Spotless + Detekt** in the CI pipeline.
+- **`build-logic/` convention plugins** to retire the repeated config across modules (currently a single-module app, but laying the foundation now keeps the eventual multi-module split mechanical).
+- **AGP-7 stability flags** in `gradle.properties` (`android.nonTransitiveRClass=false`, `android.newDsl=false`, etc.) flipped on by one to clear the deprecation warnings.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,29 @@ Specifications:
 
 * App utilizes stable release versions of all libraries, Gradle, and Android Studio.
 
+> Historical note: the Udacity rubric required Java; this app was converted to Kotlin after submission and has since been brought onto a Google-recommended stack — see "Tech stack" below.
+
+## Tech stack
+
+The data, DI, imaging, and JSON layers all sit on the modern Android target stack. The UI layer is still XML/Activities; the Compose migration is the last big lane.
+
+| Concern | Library / pattern |
+|---|---|
+| Language | Kotlin 2.2 |
+| Min SDK | 26 (adaptive launcher icon, no `mipmap-*dpi/` PNG fallbacks) |
+| Build | Gradle 9.4 with Kotlin DSL + `gradle/libs.versions.toml` version catalog |
+| DI | Hilt 2.56 (`@HiltAndroidApp`, `@HiltViewModel`, `@AndroidEntryPoint`) |
+| Async | Coroutines + Flow / StateFlow (no RxJava, no LiveData) |
+| Networking | Retrofit 2.11 `suspend` + OkHttp + `converter-kotlinx-serialization` |
+| JSON | kotlinx.serialization 1.7 (compile-time, no reflection) |
+| Local persistence | Room 2.7 — DAO reads return `Flow`, writes are `suspend` |
+| Image loading | Coil 2.7 — accessed only through a `ui.image.ImageLoader` interface |
+| Connectivity | `NetworkMonitor` interface backed by `ConnectivityManager.NetworkCallback`; observed reactively from VMs |
+| Coverage | Kover (≥60% line gate, enforced in CI) |
+| UI (still legacy) | XML layouts + DataBinding + ViewBinding, two Activities (`MainActivity` / `DetailActivity`) — migration to Jetpack Compose + Navigation-Compose pending |
+
+For the full set of decisions and constraints driving this stack — including the LoD-and-abstractions rule that drove the `MovieRepository` interface and the `ImageLoader` indirection — see [CLAUDE.md](./CLAUDE.md).
+
 Kindly note that you will need an API Key from [TMDB.org][1]. in order to build and try this application
 
 Add the following line to \[USER_HOME]/.gradle/gradle.properties


### PR DESCRIPTION
Closes #28

## Summary

CLAUDE.md and README still read like a mid-migration repo even though every §2 target-stack lane is done. This sweep brings the docs in line with reality.

### CLAUDE.md
- **§1 (context):** rewrite the "mid-modernization" paragraph. The data/DI/imaging/JSON layers are on the target stack; the UI layer (XML + DataBinding + Activities) is the last legacy lane.
- **§2 (target-stack table):** swap the \`Replaces (legacy)\` column for a \`Status\` column with per-row migration state (Done with PR ref / Partial / Pending). Added new rows for the things that landed in this cycle (Connectivity \`NetworkMonitor\`, launcher SDK floor).
- **§5 (coverage rules):** replace stale bullets (Dagger excludes, AppExecutors, ConnectionUtils Robolectric-bridge note) with the current Hilt-codegen exclude list and the test surface that ViewModels actually present (\`mock<MovieRepository>()\` + \`SavedStateHandle\`).
- **§6 (toolchain):** collapse the "Active in #18 / After #20 / After #24" timeline into a single statement of current direct deps. Versions still flow from \`gradle/libs.versions.toml\`.
- **§7 (architecture):** renamed "Legacy architecture (what's there now)" → "Current architecture". Moved the still-legacy bits (UI → Compose, UiState consolidation, KSP, Spotless/Detekt, build-logic convention plugins, AGP-7 stability flags) into a "Still to migrate" subsection. Added the **identity-vs-equality rule** that caught the favorite-heart bug in #27 (compare \`Movie\` instances by \`movieId\`, not full data-class \`==\`, since DTO-mapped and Entity-mapped \`Movie\`s differ on \`isFavorite\`).

### README.md
- New **Tech stack** table reflecting the current state (Hilt / Coroutines / kotlinx.serialization / Coil / Room+Flow / Kover) and calling out the still-legacy UI layer. Points at \`CLAUDE.md\` for the full decision set.
- The historical Udacity rubric block stays intact with a one-line note explaining the Kotlin divergence.

### GitHub repo topics
- Removed: \`rxjava3\`, \`dagger2\`, \`glide\` (all retired).
- Added: \`hilt\`, \`coil\`, \`kotlinx-serialization\`.

## Test plan
- [x] Visual review of the rendered CLAUDE.md and README on GitHub.
- [x] Topics: confirmed via \`gh repo view --json repositoryTopics\`.
- [ ] No code touched → CI is informational only.