### PR TITLE
docs: rewrite README around app purpose, stack, and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,94 @@
-# Popular-Movies2
-This product uses the TMDb API but is not endorsed or certified by TMDb.
+# Popular Movies
 
+A small Android app that browses popular and top-rated movies from [The Movie DB][tmdb], lets you read reviews and play trailers on the detail screen, and bookmark favorites locally — viewable offline.
 
-This is the second project in Udacity Android Nanodegree course purely for educational purposes
+> _This product uses the TMDb API but is not endorsed or certified by TMDb._
 
-## Stage 2: Trailers, Reviews, and Favorites
+<p>
+  <img src="ScreenShots/01-popular-portrait.png" width="220" alt="Popular grid">
+  <img src="ScreenShots/04-detail-portrait.png" width="220" alt="Detail screen">
+  <img src="ScreenShots/03-favorites-portrait.png" width="220" alt="Favorites grid">
+</p>
 
-User Experience
-In this stage you’ll add additional functionality to the app you built in Stage 1.
+## What it does
 
-You’ll add more information to your movie details view:
-
-Your app will:
-- You’ll allow users to view and play trailers ( either in the youtube app or a web browser).
-- You’ll allow users to read reviews of a selected movie.
-- You’ll also allow users to mark a movie as a favorite in the details view by tapping a button(star). This is for a local movies collection that you will maintain and does not require an API request*.
-- You’ll modify the existing sorting criteria for the main view to include an additional pivot to show their favorites collection.
-
-Specifications:
-* App is written in Kotlin. _(The Udacity rubric required Java; the project was converted to Kotlin after submission — see "Tech stack" below.)_
-
-* Movies are displayed in the main layout via a grid of their corresponding movie poster thumbnails.
-
-* UI contains an element (i.e a spinner or settings menu) to toggle the sort order of the movies by: most popular, highest rated.
-
-* UI contains a screen for displaying the details for a selected movie.
-
-* Movie details layout contains title, release date, movie poster, vote average, and plot synopsis.
-
-* App utilizes stable release versions of all libraries, Gradle, and Android Studio.
+- **Browse** popular and top-rated movie posters in a grid (2 columns portrait, 4 landscape).
+- **Open a detail screen** showing title, release date, vote, overview, trailers, and reviews.
+- **Favorite** a movie with the heart icon. Favorites persist locally in Room and stay accessible while offline.
+- **Reacts to connectivity changes live** — losing signal mid-session swaps to the offline UI within seconds; regaining signal auto-reloads the grid.
 
 ## Tech stack
 
-The data, DI, imaging, and JSON layers all sit on the modern Android target stack. The UI layer is still XML/Activities; the Compose migration is the last big lane.
+Every cross-layer dependency is an interface; the concrete is bound in a Hilt module. ViewModels mock against the interface. See [CLAUDE.md](./CLAUDE.md) for the full decision set and conventions (including the Law-of-Demeter rule and the identity-vs-equality rule that informed the data-model split).
 
-| Concern | Library / pattern |
+| Concern | Choice |
 |---|---|
-| Language | Kotlin 2.2 |
-| Min SDK | 26 (adaptive launcher icon, no `mipmap-*dpi/` PNG fallbacks) |
-| Build | Gradle 9.4 with Kotlin DSL + `gradle/libs.versions.toml` version catalog |
-| DI | Hilt 2.56 (`@HiltAndroidApp`, `@HiltViewModel`, `@AndroidEntryPoint`) |
-| Async | Coroutines + Flow / StateFlow (no RxJava, no LiveData) |
+| Language / SDK | Kotlin 2.2 · `minSdk` 26 · `compileSdk` 34 |
+| Build | Gradle 9.4 (Kotlin DSL) · version catalog (`gradle/libs.versions.toml`) · AGP 9.2 |
+| DI | **Hilt** 2.56 |
+| Async | **Coroutines + Flow / StateFlow** — no RxJava, no LiveData |
 | Networking | Retrofit 2.11 `suspend` + OkHttp + `converter-kotlinx-serialization` |
-| JSON | kotlinx.serialization 1.7 (compile-time, no reflection) |
+| JSON | **kotlinx.serialization** 1.7 (compile-time, no reflection) |
 | Local persistence | Room 2.7 — DAO reads return `Flow`, writes are `suspend` |
-| Image loading | Coil 2.7 — accessed only through a `ui.image.ImageLoader` interface |
-| Connectivity | `NetworkMonitor` interface backed by `ConnectivityManager.NetworkCallback`; observed reactively from VMs |
-| Coverage | Kover (≥60% line gate, enforced in CI) |
-| UI (still legacy) | XML layouts + DataBinding + ViewBinding, two Activities (`MainActivity` / `DetailActivity`) — migration to Jetpack Compose + Navigation-Compose pending |
+| Image loading | **Coil** 2.7, hidden behind a `ui.image.ImageLoader` interface |
+| Connectivity | `NetworkMonitor` interface wrapping `ConnectivityManager.NetworkCallback` as `Flow<Boolean>` |
+| Coverage | **Kover** (≥60% line gate in CI) |
+| UI (last legacy lane) | XML layouts + DataBinding/ViewBinding + two Activities — Compose + Navigation-Compose migration pending |
 
-For the full set of decisions and constraints driving this stack — including the LoD-and-abstractions rule that drove the `MovieRepository` interface and the `ImageLoader` indirection — see [CLAUDE.md](./CLAUDE.md).
+## Architecture
 
-Kindly note that you will need an API Key from [TMDB.org][1]. in order to build and try this application
+```
+@AndroidEntryPoint Activity
+        │
+        ▼  (by viewModels())
+@HiltViewModel MainViewModel / DetailViewModel
+        │
+        ▼  (constructor injection)
+MovieRepository  (interface)
+        │
+        ▼
+MovieRepositoryImpl
+        ├─► NetworkDataSource ──► Retrofit suspend  ──► TMDb API
+        │                          (MovieDto → Movie at the data-source edge)
+        └─► LocalDataSource  ──► Room Flow / suspend ──► favorite_movies.db
+                                   (MovieEntity → Movie at the data-source edge)
+```
 
-Add the following line to \[USER_HOME]/.gradle/gradle.properties
+`Movie` is a `@Parcelize` domain type with no Room or kotlinx.serialization annotations on it; `MovieEntity` and `MovieDto` are package-internal concerns mapped via `data/Mappers.kt`. The repository public surface speaks domain types only.
 
-For Windows OS, example for Denis user:
+## Build
 
-    C:\Users\Denis\.gradle
-    
-find the gradle.properties file and write in it :
+You need a TMDb v3 API key. Sign up at [themoviedb.org][tmdb-signup] (free) and grab a v3 key from your account's "API" page.
 
-**myTMDBApiKey="<_YOUR-API-KEY_>"** 
+The build reads the key from a Gradle property called `myTMDBApiKey` and emits it as `BuildConfig.TMDB_API_KEY`. Add it **once** to your **user-level** Gradle properties — never to the repo's `gradle.properties`:
 
-[1]:https://developers.themoviedb.org/3/getting-started/introduction
+| OS | File |
+|---|---|
+| macOS / Linux | `~/.gradle/gradle.properties` |
+| Windows | `%USERPROFILE%\.gradle\gradle.properties` |
+
+```properties
+myTMDBApiKey="<your-v3-key-here>"
+```
+
+The surrounding double-quotes are required — the value is interpolated verbatim into a Java string literal by `buildConfigField`.
+
+Then:
+
+```bash
+./gradlew installDebug          # build + push to a connected device/emulator
+./gradlew test                  # JVM unit tests
+./gradlew koverHtmlReport       # coverage HTML at app/build/reports/kover/html/
+./gradlew koverVerify           # fail if line coverage < 60%
+```
+
+For the full list of supported tasks, see [CLAUDE.md §5](./CLAUDE.md#5-common-commands).
+
+## Project history
+
+The original 2020 codebase was a Udacity Android Developer Nanodegree _Stage 2: Trailers, Reviews, and Favorites_ submission. It was Java + Dagger 2 + RxJava 3 + LiveData + DataBinding + Glide + Gson on AGP 4.1. Since then the data, DI, JSON, and imaging layers have all been migrated to the Google-recommended target stack listed above; the UI layer (XML + Activities) is the last lane, scheduled for the Compose migration.
+
+Per Udacity Honor Code, the original submission files carry a header noting the code is reference-only. Preserve those headers when editing existing files. New files written during the modernization do not require it.
 
 ## Screenshots
 
@@ -86,3 +111,6 @@ find the gradle.properties file and write in it :
 | Favorites | Detail |
 | --- | --- |
 | <img src="ScreenShots/08-favorites-landscape.png" width="480"> | <img src="ScreenShots/09-detail-landscape.png" width="480"> |
+
+[tmdb]: https://www.themoviedb.org/
+[tmdb-signup]: https://developers.themoviedb.org/3/getting-started/introduction

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your app will:
 - You’ll modify the existing sorting criteria for the main view to include an additional pivot to show their favorites collection.
 
 Specifications:
-* App is written solely in the Java Programming Language.
+* App is written in Kotlin. _(The Udacity rubric required Java; the project was converted to Kotlin after submission — see "Tech stack" below.)_
 
 * Movies are displayed in the main layout via a grid of their corresponding movie poster thumbnails.
 
@@ -29,8 +29,6 @@ Specifications:
 * Movie details layout contains title, release date, movie poster, vote average, and plot synopsis.
 
 * App utilizes stable release versions of all libraries, Gradle, and Android Studio.
-
-> Historical note: the Udacity rubric required Java; this app was converted to Kotlin after submission and has since been brought onto a Google-recommended stack — see "Tech stack" below.
 
 ## Tech stack
 


### PR DESCRIPTION
Closes #30

Restructures the README from "Udacity rubric checklist + screenshots dump" to "what the app does → stack → architecture → build → history → screenshots". The earlier one-line Kotlin fix (#30 v1) rolls into this larger rewrite.

## What changed

- **Lead** with the elevator pitch + a three-shot screenshot strip (Popular / Detail / Favorites portrait thumbnails). The Udacity preamble dropped from the top.
- **What it does** — feature list including the live-reactive offline behavior (because that's a non-obvious capability worth surfacing).
- **Tech stack** — same content trimmed to two columns; prefaced by the cross-layer-interface convention so readers know to look at \`MovieRepository\` not \`MovieRepositoryImpl\`; links to \`CLAUDE.md\` for the full ruleset.
- **Architecture** — new section with an ASCII diagram of the layered DI / data flow. One-line note on the Movie / MovieDto / MovieEntity split mapped via \`data/Mappers.kt\`.
- **Build** — TMDb key setup as a per-OS table; drops the "for Denis user" example path. Canonical gradle tasks listed.
- **Project history** — preserves the Udacity context + the modernization arc (Java + Dagger 2 + RxJava 3 + LiveData + DataBinding + Glide + Gson + AGP 4.1 → current stack) without the stale Udacity rubric checkboxes (which no longer describe the current state and added noise).
- **Screenshots** — unchanged (refreshed in #15; no re-shoot needed).
- **Links** — moved external links to reference-style at the bottom for legibility.

## Test plan
- [x] No code touched → CI is informational only.
- [x] Visual review of the rendered README will tell — preview-friendly.